### PR TITLE
Use new SSO auth headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,10 @@ http.createServer(function (req, res) {
   else if (uri.pathname == "/") {
     res.writeHead(200, nocache({"Content-Type": "text/html"}));
 
-    var user = req.headers["adfs_login"];
-    var name = req.headers["adfs_fullname"];
-    var groups = req.headers["adfs_group"];
-    groups = (groups === undefined) ? [] : groups.split(";");
+    var user = req.headers["oidc_claim_sub"];
+    var name = req.headers["oidc_claim_name"];
+    var groups = req.headers["oidc_claim_cern_roles"];
+    groups = (groups === undefined) ? [] : groups.split(",");
 
     content = "";
     content += boolitem(user !== undefined && name !== undefined,


### PR DESCRIPTION
The new CERN SSO is based on OIDC, not Shibboleth, so it exposes slightly different headers.

They're quite straightforward to rename, though `oidc_claim_cern_roles` relies on the `alice-member` role being defined for the alisw "application" on https://application-portal.web.cern.ch/.

The new groups header is also comma-separated, not semicolon-separated.